### PR TITLE
Update main.rs

### DIFF
--- a/aoc01/src/main.rs
+++ b/aoc01/src/main.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::io::{self, Read, Write};
 
-type Result<T> = ::std::result::Result<T, Box<::std::error::Error>>;
+type Result<T> = ::std::result::Result<T, Box<dyn ::std::error::Error>>;
 
 fn main() -> Result<()> {
     let mut input = String::new();


### PR DESCRIPTION
warning: trait objects without an explicit `dyn` are deprecated